### PR TITLE
Apply SSL standardization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 0.0.1 (UNRELEASED)
   - Minimal bootstrap of Logstash to Logstash plugin [#1](https://github.com/logstash-plugins/logstash-integration-logstash/pull/2)
   - Complete bootstrap and fix documentation [#3](https://github.com/logstash-plugins/logstash-integration-logstash/pull/3)
+  - Apply SSL standardization [#7](https://github.com/logstash-plugins/logstash-integration-logstash/pull/7)

--- a/docs/input-logstash.asciidoc
+++ b/docs/input-logstash.asciidoc
@@ -116,7 +116,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> | <<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_path>> | <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> | <<password,password>>|No
-| <<plugins-{type}s-{plugin}-ssl_verification_mode>> | <<string,string>>, one of `["certificate"]`|No
 | <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
 |=======================================================================
 
@@ -235,25 +234,6 @@ A path to a JKS- or PKCS12-formatted keystore with which to identify this plugin
 * Cannot be combined with configurations that disable SSL.
 
 A password or passphrase of the <<plugins-{type}s-{plugin}-ssl_key>>.
-
-[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
-===== `ssl_verification_mode`
-
-* Value type is <<string,string>>
-* There is only one currently-supported mode:
-** `certificate`: verifies that a certificate provided by the client is signed by a trusted authority (CA), is within its valid date range, and that the client has possession of the associated key, but does _not_ perform hostname validation.
-// NOTE: `ssl_verification_mode => full` is pending upstream support, but when it arrives it will look like:
-////
-** `full`: fully validates the certificate as in `certificate` mode, and also validates that the client's outbound IP address is represented in the certificate's identity claims for `subject` and/or `subjectAltName`.
-////
-* The default value is `certificate`.
-* Cannot be combined with configurations that disable SSL.
-* Cannot be combined with <<plugins-{type}s-{plugin}-ssl_client_authentication, `+ssl_client_authentication => none+`>>.
-
-When <<plugins-{type}s-{plugin}-ssl_client_authentication>> causes a client to present a certificate, this setting controls how that certificate is verified.
-
-NOTE: Client identity is not typically validated using SSL because the receiving server only has access to the client's outbound-ip, which is not always constant and is frequently not represented in the certificate's subject or subjectAltNames extensions.
-For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC2818 § 3.2 (HTTP over TLS -- Client Identity)]
 
 [id="plugins-{type}s-{plugin}-username"]
 ===== `username`

--- a/docs/output-logstash.asciidoc
+++ b/docs/output-logstash.asciidoc
@@ -22,7 +22,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 ==== Description
 
-Send events to a <<plugins-outputs-logstash>> in a pipeline that may be in another process or on another host.
+Send events to a <<plugins-inputs-logstash>> in a pipeline that may be in another process or on another host.
 You must have a TCP route to the port on an interface that the downstream input is bound to.
 
 NOTE: Sending events to _any_ destination other than <<plugins-inputs-logstash>> is neither advised nor supported.
@@ -173,8 +173,7 @@ You can disable SSL with `+ssl_enabled => false+`. When disabled, setting any `s
 * When present, <<plugins-{type}s-{plugin}-ssl_key>> is also required.
 * Cannot be combined with configurations that disable SSL.
 
-Path to a PEM-encoded certificate or certificate chain with which to identify this plugin to connecting clients.
-The certificate _SHOULD_ include identity claims about the ip address or hostname that clients use to establish a connection.
+Path to a PEM-encoded certificate or certificate chain with which to identify this plugin to connecting downstream input.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
 ===== `ssl_certificate_authorities`
@@ -184,8 +183,8 @@ The certificate _SHOULD_ include identity claims about the ip address or hostnam
 * Cannot be combined with configurations that disable SSL.
 * Cannot be combined with <<plugins-{type}s-{plugin}-ssl_verification_mode, `+ssl_verification_mode => none+`>>.
 
-One or more PEM-encoded files defining certificate authorities for use in client authentication.
-This setting can be used to _override_ the system trust store for verifying the SSL certificate presented by clients.
+One or more PEM-encoded files defining certificate authorities for use in downstream input authentication.
+This setting can be used to _override_ the system trust store for verifying the SSL certificate presented by downstream input.
 
 [id="plugins-{type}s-{plugin}-ssl_key"]
 ===== `ssl_key`
@@ -251,10 +250,7 @@ Password for the <<plugins-{type}s-{plugin}-ssl_truststore_path>>
 * The default value is `full`.
 * Cannot be combined with configurations that disable SSL.
 
-When <<plugins-{type}s-{plugin}-ssl_client_authentication>> causes a client to present a certificate, this setting controls how that certificate is verified.
-
-NOTE: Client identity is not typically validated using SSL because the receiving server only has access to the client's outbound-ip, which is not always constant and is frequently not represented in the certificate's subject or subjectAltNames extensions.
-For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC2818 § 3.2 (HTTP over TLS -- Client Identity)]
+When communicating over SSL, this setting controls how the downstream input's certificate is verified.
 
 [id="plugins-{type}s-{plugin}-username"]
 ===== `username`

--- a/lib/logstash/inputs/logstash.rb
+++ b/lib/logstash/inputs/logstash.rb
@@ -138,8 +138,7 @@ class LogStash::Inputs::Logstash < LogStash::Inputs::Base
         report_invalid_config!('`ssl_key_passphrase` is not allowed unless `ssl_key` is configured')
       elsif @ssl_keystore_path
         identity_options['ssl_keystore_path'] = @ssl_keystore_path
-        report_invalid_config!('Non-empty `ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is configured') if @ssl_keystore_password.nil? || @ssl_keystore_password.value.empty?
-        identity_options['ssl_keystore_password'] = @ssl_keystore_password
+        identity_options['ssl_keystore_password'] = @ssl_keystore_password || report_invalid_config!('`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is configured')
       elsif @ssl_keystore_password
         report_invalid_config!('`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured')
       else

--- a/lib/logstash/inputs/logstash.rb
+++ b/lib/logstash/inputs/logstash.rb
@@ -32,7 +32,6 @@ class LogStash::Inputs::Logstash < LogStash::Inputs::Base
 
   # SSL:TRUST:CONFIG
   config :ssl_client_authentication,   :validate => %w(none optional required), :default => 'none'
-  config :ssl_verification_mode,       :validate => %w(certificate),            :default => 'certificate'
 
   # SSL:TRUST:SOURCE ca file
   config :ssl_certificate_authorities, :validate => :path, :list => true
@@ -133,6 +132,7 @@ class LogStash::Inputs::Logstash < LogStash::Inputs::Base
       elsif @ssl_certificate
         identity_options['ssl_certificate'] = @ssl_certificate
         report_invalid_config!('`ssl_key_passphrase` is not allowed unless `ssl_key` is configured') if @ssl_key.nil? && @ssl_key_passphrase
+        report_invalid_config!('Empty `ssl_key_passphrase` is not allowed') if !@ssl_key.nil? && @ssl_key_passphrase && @ssl_key_passphrase.value.empty?
         identity_options['ssl_key'] = @ssl_key unless @ssl_key.nil?
         identity_options['ssl_key_passphrase'] = @ssl_key_passphrase unless @ssl_key_passphrase.nil?
       elsif @ssl_key
@@ -141,7 +141,8 @@ class LogStash::Inputs::Logstash < LogStash::Inputs::Base
         report_invalid_config!('`ssl_key_passphrase` is not allowed unless `ssl_key` is configured')
       elsif @ssl_keystore_path
         identity_options['ssl_keystore_path'] = @ssl_keystore_path
-        identity_options['ssl_keystore_password'] = @ssl_keystore_password || report_invalid_config!('`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is configured')
+        report_invalid_config!('Non-empty `ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is configured') if @ssl_keystore_password.nil? || @ssl_keystore_password.value.empty?
+        identity_options['ssl_keystore_password'] = @ssl_keystore_password
       elsif @ssl_keystore_password
         report_invalid_config!('`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured')
       else

--- a/lib/logstash/outputs/logstash.rb
+++ b/lib/logstash/outputs/logstash.rb
@@ -130,7 +130,6 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
     elsif @ssl_keystore_path
       return {
         'ssl_keystore_path' => @ssl_keystore_path,
-        'ssl_keystore_type' => keystore_type(@ssl_keystore_path),
         'ssl_keystore_password' => @ssl_keystore_password || fail(LogStash::ConfigurationError, "`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided"),
       }
     elsif @ssl_keystore_password
@@ -154,16 +153,10 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
         fail(LogStash::ConfigurationError, 'SSL Truststore cannot be configured when `ssl_verification_mode => none`') if @ssl_verification_mode == 'none'
 
         trust_options['ssl_truststore_path'] = @ssl_truststore_path
-        trust_options['ssl_truststore_type'] = keystore_type(@ssl_truststore_path)
         trust_options['ssl_truststore_password'] = @ssl_truststore_password || fail(LogStash::ConfigurationError, '`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided')
       elsif @ssl_truststore_password
         fail(LogStash::ConfigurationError, '`ssl_truststore_password` not allowed unless `ssl_truststore_path` is configured')
       end
     end
-  end
-
-  def keystore_type(keystore_path)
-    return 'jks' if keystore_path.downcase.end_with?('.jks')
-    return 'pkcs12'
   end
 end

--- a/lib/logstash/outputs/logstash.rb
+++ b/lib/logstash/outputs/logstash.rb
@@ -123,15 +123,20 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
       fail(LogStash::ConfigurationError, 'SSL identity can be configured with EITHER `ssl_certificate` OR `ssl_keystore_*`, but not both')
     elsif @ssl_certificate
       return {
-        'client_cert' => @ssl_certificate,
-        'client_key'  => @ssl_key || fail("`ssl_key` is REQUIRED when `ssl_certificate` is provided"),
+        'ssl_certificate' => @ssl_certificate,
+        'ssl_key'  => @ssl_key || fail(LogStash::ConfigurationError, "`ssl_key` is REQUIRED when `ssl_certificate` is provided"),
       }
+    elsif @ssl_key
+      fail(LogStash::ConfigurationError, '`ssl_key` is not allowed unless `ssl_certificate` is configured')
     elsif @ssl_keystore_path
+      fail(LogStash::ConfigurationError, "Non-empty `ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided") if @ssl_keystore_password.nil? || @ssl_keystore_password.value.empty?
       return {
-        'keystore' => @ssl_keystore_path,
-        'keystore_type' => keystore_type(@ssl_keystore_path),
-        'keystore_password' => @ssl_keystore_password || fail("`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided"),
+        'ssl_keystore_path' => @ssl_keystore_path,
+        'ssl_keystore_type' => keystore_type(@ssl_keystore_path),
+        'ssl_keystore_password' => @ssl_keystore_password,
       }
+    elsif @ssl_keystore_password
+      fail(LogStash::ConfigurationError, "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured")
     else
       return {}
     end
@@ -146,19 +151,22 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
       elsif @ssl_certificate_authorities&.any?
         fail(LogStash::ConfigurationError, 'SSL Certificate Authorities cannot be configured when `ssl_verification_mode => none`') if @ssl_verification_mode == 'none'
 
-        trust_options['cacert'] = @ssl_certificate_authorities.first
+        trust_options['ssl_certificate_authorities'] = @ssl_certificate_authorities.first
       elsif @ssl_truststore_path
         fail(LogStash::ConfigurationError, 'SSL Truststore cannot be configured when `ssl_verification_mode => none`') if @ssl_verification_mode == 'none'
+        fail(LogStash::ConfigurationError, 'Non-empty `ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided') if @ssl_truststore_password.nil? || @ssl_truststore_password.value.empty?
 
-        trust_options['truststore'] = @ssl_truststore_path
-        trust_options['truststore_type'] = keystore_type(@ssl_truststore_path)
-        trust_options['truststore_password'] = @ssl_truststore_password || fail("`truststore_password` is REQUIRED when `ssl_truststore_path` is provided")
+        trust_options['ssl_truststore_path'] = @ssl_truststore_path
+        trust_options['ssl_truststore_type'] = keystore_type(@ssl_truststore_path)
+        trust_options['ssl_truststore_password'] = @ssl_truststore_password
+      elsif @ssl_truststore_password
+        fail(LogStash::ConfigurationError, '`ssl_truststore_password` not allowed unless `ssl_truststore_path` is configured')
       end
     end
   end
 
   def keystore_type(keystore_path)
-    return 'JKS' if keystore_path.downcase.end_with?('.jks')
-    return 'PKCS12'
+    return 'jks' if keystore_path.downcase.end_with?('.jks')
+    return 'pkcs12'
   end
 end

--- a/lib/logstash/outputs/logstash.rb
+++ b/lib/logstash/outputs/logstash.rb
@@ -128,11 +128,10 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
     elsif @ssl_key
       fail(LogStash::ConfigurationError, '`ssl_key` is not allowed unless `ssl_certificate` is configured')
     elsif @ssl_keystore_path
-      fail(LogStash::ConfigurationError, "Non-empty `ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided") if @ssl_keystore_password.nil? || @ssl_keystore_password.value.empty?
       return {
         'ssl_keystore_path' => @ssl_keystore_path,
         'ssl_keystore_type' => keystore_type(@ssl_keystore_path),
-        'ssl_keystore_password' => @ssl_keystore_password,
+        'ssl_keystore_password' => @ssl_keystore_password || fail(LogStash::ConfigurationError, "`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided"),
       }
     elsif @ssl_keystore_password
       fail(LogStash::ConfigurationError, "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured")
@@ -153,11 +152,10 @@ class LogStash::Outputs::Logstash < LogStash::Outputs::Base
         trust_options['ssl_certificate_authorities'] = @ssl_certificate_authorities.first
       elsif @ssl_truststore_path
         fail(LogStash::ConfigurationError, 'SSL Truststore cannot be configured when `ssl_verification_mode => none`') if @ssl_verification_mode == 'none'
-        fail(LogStash::ConfigurationError, 'Non-empty `ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided') if @ssl_truststore_password.nil? || @ssl_truststore_password.value.empty?
 
         trust_options['ssl_truststore_path'] = @ssl_truststore_path
         trust_options['ssl_truststore_type'] = keystore_type(@ssl_truststore_path)
-        trust_options['ssl_truststore_password'] = @ssl_truststore_password
+        trust_options['ssl_truststore_password'] = @ssl_truststore_password || fail(LogStash::ConfigurationError, '`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided')
       elsif @ssl_truststore_password
         fail(LogStash::ConfigurationError, '`ssl_truststore_password` not allowed unless `ssl_truststore_path` is configured')
       end

--- a/logstash-integration-logstash.gemspec
+++ b/logstash-integration-logstash.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-mixin-plugin_factory_support", "~> 1.0"
   s.add_runtime_dependency "logstash-codec-json_lines", "~> 3.1"
 
-  s.add_runtime_dependency "logstash-input-http"
-  s.add_runtime_dependency "logstash-output-http"
+  s.add_runtime_dependency "logstash-input-http", ">= 3.7.0"  # some params not available in older versions because they are renamed, such as `cacert` to `ssl_certificate_authorities`
+  s.add_runtime_dependency "logstash-output-http", ">= 5.6.0"
 
   s.add_development_dependency "logstash-devutils"
   s.add_development_dependency "rspec-collection_matchers"

--- a/spec/unit/logstash_input_spec.rb
+++ b/spec/unit/logstash_input_spec.rb
@@ -86,25 +86,12 @@ describe LogStash::Inputs::Logstash do
           end
         end
 
-        context "with `ssl_key_passphrase`" do
+        context "without `ssl_key`" do
           let(:config) { super().merge("ssl_key_passphrase" => "pa$$w0rd") }
 
-          it "requires `ssl_key`" do
-            expected_message = '`ssl_key_passphrase` is not allowed unless `ssl_key` is configured'
+          it "is not allowed" do
+            expected_message = '`ssl_key` is required when `ssl_certificate` is configured'
             expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
-          end
-        end
-
-        context "with `ssl_key`" do
-          let(:config) { super().merge("ssl_key" => cert_fixture!('server_from_root.key.pkcs8.pem')) }
-
-          context "with empty `ssl_key_passphrase`" do
-            let(:config) { super().merge("ssl_key_passphrase" => "") }
-
-            it "is not allowed" do
-              expected_message = 'Empty `ssl_key_passphrase` is not allowed'
-              expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
-            end
           end
         end
       end
@@ -130,8 +117,8 @@ describe LogStash::Inputs::Logstash do
       context "`ssl_keystore_path`" do
         let(:config) { super().merge("ssl_keystore_path" => cert_fixture!('server_from_root.jks')) }
 
-        it "requires non-empty `ssl_keystore_password`" do
-          expected_message = 'Non-empty `ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is configured'
+        it "requires `ssl_keystore_password`" do
+          expected_message = '`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is configured'
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end

--- a/spec/unit/logstash_input_spec.rb
+++ b/spec/unit/logstash_input_spec.rb
@@ -30,7 +30,7 @@ describe LogStash::Inputs::Logstash do
 
     let(:registered_plugin) { plugin.tap(&:register) }
 
-    describe "username and password auth" do
+    context "username and password auth" do
       let(:config) { super().merge("host" => "my-ls-upstream.com", "ssl_enabled" => false) }
 
       context "with `username`" do
@@ -70,7 +70,7 @@ describe LogStash::Inputs::Logstash do
       end
     end
 
-    context "with SSL disabled" do
+    context "SSL disabled" do
       let(:config) { super().merge("ssl_enabled" => false) }
 
       context "with SSL related configs" do
@@ -83,6 +83,100 @@ describe LogStash::Inputs::Logstash do
       end
 
     end
-  end
 
+    context "self identity" do
+      let(:config) { super().merge("ssl_enabled" => true) }
+
+      it "requires SSL identity" do
+        expected_message = 'SSL identity MUST be configured with either `ssl_certificate`/`ssl_key` or `ssl_keystore_*`'
+        expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+      end
+
+      context "SSL certificate" do
+        let(:config) { super().merge("ssl_certificate" => cert_fixture!('server_from_root.pem')) }
+
+        context "with keystore" do
+          let(:config) { super().merge("ssl_keystore_path" => cert_fixture!('client_from_root.jks')) }
+
+          it "cannot be used together" do
+            expected_message = 'SSL identity can be configured with EITHER `ssl_certificate` OR `ssl_keystore_*`, but not both'
+            expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+          end
+        end
+
+        context "with `ssl_key_passphrase`" do
+          let(:config) { super().merge("ssl_key_passphrase" => "pa$$w0rd") }
+
+          it "requires `ssl_key`" do
+            expected_message = '`ssl_key_passphrase` is not allowed unless `ssl_key` is configured'
+            expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+          end
+        end
+
+        context "with `ssl_key`" do
+          let(:config) { super().merge("ssl_key" => cert_fixture!('server_from_root.key.pkcs8.pem')) }
+
+          context "with empty `ssl_key_passphrase`" do
+            let(:config) { super().merge("ssl_key_passphrase" => "") }
+
+            it "is not allowed" do
+              expected_message = 'Empty `ssl_key_passphrase` is not allowed'
+              expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+            end
+          end
+        end
+      end
+
+      context "`ssl_key`" do
+        let(:config) { super().merge("ssl_key" => cert_fixture!('server_from_root.key.pkcs8.pem')) }
+
+        it "requires SSL certificate" do
+          expected_message = '`ssl_key` is not allowed unless `ssl_certificate` is configured'
+          expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+        end
+      end
+
+      context "`ssl_key_passphrase`" do
+        let(:config) { super().merge("ssl_key_passphrase" => "pa$$w0rd") }
+
+        it "requires SSL key" do
+          expected_message = '`ssl_key_passphrase` is not allowed unless `ssl_key` is configured'
+          expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+        end
+      end
+
+      context "`ssl_keystore_path`" do
+        let(:config) { super().merge("ssl_keystore_path" => cert_fixture!('server_from_root.jks')) }
+
+        it "requires non-empty `ssl_keystore_password`" do
+          expected_message = 'Non-empty `ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is configured'
+          expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+        end
+      end
+
+      context "`ssl_keystore_password`" do
+        let(:config) { super().merge("ssl_keystore_password" => "pa$$w0rd") }
+
+        it "requires `ssl_keystore_path`" do
+          expected_message = '`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is configured'
+          expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+        end
+      end
+    end
+
+    context "trust with CA" do
+      let(:config) { super().merge(
+        "ssl_enabled" => true,
+        "ssl_certificate_authorities" => cert_fixture!('root.pem'),
+        "ssl_keystore_path" => cert_fixture!('server_from_root.jks'),
+        "ssl_keystore_password" => "pa$$w0rd"
+        # default `ssl_client_authentication` is 'none'
+      ) }
+
+      it "requires SSL Client Authentication" do
+        expected_message = '`ssl_certificate_authorities` is not supported because `ssl_client_authentication => none`'
+        expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
+      end
+    end
+  end
 end

--- a/spec/unit/logstash_output_spec.rb
+++ b/spec/unit/logstash_output_spec.rb
@@ -98,8 +98,8 @@ describe LogStash::Outputs::Logstash do
       context "`ssl_keystore_path`" do
         let(:config) { super().merge("ssl_keystore_path" => cert_fixture!('server_from_root.jks')) }
 
-        it "requires non-empty `ssl_keystore_password`" do
-          expected_message = 'Non-empty `ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided'
+        it "requires `ssl_keystore_password`" do
+          expected_message = '`ssl_keystore_password` is REQUIRED when `ssl_keystore_path` is provided'
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
       end
@@ -143,7 +143,7 @@ describe LogStash::Outputs::Logstash do
         let(:config) { super().merge("ssl_truststore_path" => cert_fixture!('client_self_signed.jks')) }
 
         it "requires truststore password" do
-          expected_message = 'Non-empty `ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided'
+          expected_message = '`ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided'
           expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
         end
 
@@ -152,15 +152,6 @@ describe LogStash::Outputs::Logstash do
 
           it "not allowed" do
             expected_message = 'SSL Truststore cannot be configured when `ssl_verification_mode => none`'
-            expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
-          end
-        end
-
-        context "path with empty password" do
-          let(:config) { super().merge("ssl_truststore_password" => "") }
-
-          it "is not allowed" do
-            expected_message = 'Non-empty `ssl_truststore_password` is REQUIRED when `ssl_truststore_path` is provided'
             expect{ registered_plugin }.to raise_error(LogStash::ConfigurationError).with_message(expected_message)
           end
         end


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?
Applies a SSL standardization work proceeded on both [`http-mixin-client`](https://github.com/elastic/logstash/issues/15191) and [http-input/output](https://github.com/elastic/logstash/issues/14930) side

## Why is it important/What is the impact to the user?
Avoid using deprecated SSL related params such as `cacert` and utilize user friendly SSL namings which are being standardized among Logstash plugins.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist
- [ ]

## How to test this PR locally

## Related issues
- Closes #4 

## Use cases

## Screenshots

## Logs
