### PR TITLE
Uncomment doc links because plugin is excluded from doc generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.1 (UNRELEASED)
+## 0.0.1
   - Minimal bootstrap of Logstash to Logstash plugin [#1](https://github.com/logstash-plugins/logstash-integration-logstash/pull/2)
   - Complete bootstrap and fix documentation [#3](https://github.com/logstash-plugins/logstash-integration-logstash/pull/3)
   - Apply SSL standardization [#7](https://github.com/logstash-plugins/logstash-integration-logstash/pull/7)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Logstash Integration Plugin
 
-// include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 

--- a/docs/input-logstash.asciidoc
+++ b/docs/input-logstash.asciidoc
@@ -1,4 +1,4 @@
-// :integration: logstash
+:integration: logstash
 :plugin: logstash
 :type: input
 :no_codec:
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Logstash input plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
@@ -247,6 +247,6 @@ When this input plugin is configured with a `username`, it also requires a <<plu
 NOTE: when SSL is disabled, credentials will be transmitted in clear-text.
 
 [id="plugins-{type}s-{plugin}-common-options"]
-// include::{include_path}/{type}.asciidoc[]
+include::{include_path}/{type}.asciidoc[]
 
 :default_codec!:

--- a/docs/output-logstash.asciidoc
+++ b/docs/output-logstash.asciidoc
@@ -1,4 +1,4 @@
-// :integration: logstash
+:integration: logstash
 :plugin: logstash
 :type: output
 :no_codec:
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Logstash output plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 
@@ -266,6 +266,6 @@ When the downstream input plugin is configured with a `username` and `password`,
 NOTE: when SSL is disabled, credentials will be transmitted in clear-text.
 
 [id="plugins-{type}s-{plugin}-common-options"]
-// include::{include_path}/{type}.asciidoc[]
+include::{include_path}/{type}.asciidoc[]
 
 :default_codec!:


### PR DESCRIPTION
### Description
Recently, I excluded the `logstash-integration-logstash` plugin from docs generation. It is not safe to enable links in the docs. Once we release the plugin, I will include the plugin back to the docs generation.
Also, note that currently I am actively working on the empty placeholder generator so that docs will not get any broken links.