### PR TITLE
Prepare initial release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.1 (UNRELEASED)
+## 0.0.1
   - Minimal bootstrap of Logstash to Logstash plugin [#1](https://github.com/logstash-plugins/logstash-integration-logstash/pull/2)
   - Complete bootstrap and fix documentation [#3](https://github.com/logstash-plugins/logstash-integration-logstash/pull/3)
   - Apply SSL standardization [#7](https://github.com/logstash-plugins/logstash-integration-logstash/pull/7)


### PR DESCRIPTION
We have been developing [`logstash-integration-logstash`](https://github.com/logstash-plugins/logstash-integration-logstash) plugin and didn't release yet. We have been listing the changelogs intentionally by defining `UNRELEASED` key that should be removed before release. This PR removes the keyword to allow the release.